### PR TITLE
Remove usage of custom aiohttp session from Eplucon client.

### DIFF
--- a/custom_components/eplucon/__init__.py
+++ b/custom_components/eplucon/__init__.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import device_registry
 from .eplucon_api.eplucon_client import EpluconApi, ApiError, DeviceDTO, BASE_URL
 from .const import DOMAIN, PLATFORMS, EPLUCON_PORTAL_URL, MANUFACTURER, SUPPORTED_TYPES
@@ -21,9 +20,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_endpoint = entry.data.get("api_endpoint", BASE_URL)
 
     devices = entry.data["devices"]
-
-    session = async_get_clientsession(hass)
-    client = EpluconApi(api_token, api_endpoint, session)
+    client = EpluconApi(api_token, api_endpoint)
 
     await register_devices(devices, entry, hass)
 

--- a/custom_components/eplucon/config_flow.py
+++ b/custom_components/eplucon/config_flow.py
@@ -32,7 +32,7 @@ class EpluconConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Attempt to connect to the API using the provided API token & endpoint
             api_token: str = user_input["api_token"]
             api_endpoint: str = user_input['api_endpoint']
-            client = EpluconApi(api_token, api_endpoint, aiohttp_client.async_get_clientsession(self.hass))
+            client = EpluconApi(api_token, api_endpoint)
 
             try:
                 devices = await client.get_devices()
@@ -96,7 +96,7 @@ class EpluconOptionsFlowHandler(config_entries.OptionsFlow):
             api_endpoint = user_input.get("api_endpoint")
 
             # Revalidate the API token to ensure it's correct
-            client = EpluconApi(api_token, api_endpoint, aiohttp_client.async_get_clientsession(self.hass))
+            client = EpluconApi(api_token, api_endpoint)
 
             try:
                 devices = await client.get_devices()

--- a/custom_components/eplucon/eplucon_api/eplucon_client.py
+++ b/custom_components/eplucon/eplucon_api/eplucon_client.py
@@ -23,9 +23,9 @@ class ApiError(Exception):
 class EpluconApi:
     """Client to talk to Eplucon API"""
 
-    def __init__(self, api_token: str, api_endpoint: str|None, session: Optional[aiohttp.ClientSession] = None) -> None:
+    def __init__(self, api_token: str, api_endpoint: str | None) -> None:
         self._base = api_endpoint if api_endpoint else BASE_URL
-        self._session = session or aiohttp.ClientSession()
+        self._session = aiohttp.ClientSession()
         self._headers = {
             "Accept": "application/json",
             "Cache-Control": "no-cache",


### PR DESCRIPTION
There have been some problem with the API not returning data. This PR is a test to see if the 'shared' `aiohttp` session of Home Assistant is the cause of this.


This PR removes the ability to give a custom session to the Eplucon client. The implementation has been updated to remove the usage of the home assistant `aiohttp` session.