### PR TITLE
Adding HeatLoading Status

### DIFF
--- a/custom_components/eplucon/__init__.py
+++ b/custom_components/eplucon/__init__.py
@@ -49,6 +49,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 realtime_info = await client.get_realtime_info(entry_device.id)
                 entry_device.realtime_info = realtime_info
 
+                heatloading_status = await client.get_heatpump_heatloading_status(entry_device.id)
+                entry_device.heatloading_status = heatloading_status
+
             return entry_devices
 
         except ApiError as err:

--- a/custom_components/eplucon/eplucon_api/DTO/DeviceDTO.py
+++ b/custom_components/eplucon/eplucon_api/DTO/DeviceDTO.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
 from .RealtimeInfoDTO import RealtimeInfoDTO
+from .HeatLoadingDTO import HeatLoadingDTO
 
 
 @dataclass
@@ -10,3 +11,4 @@ class DeviceDTO:
     name: str
     type: str
     realtime_info: Optional[RealtimeInfoDTO] = None
+    heatloading_status: Optional[HeatLoadingDTO] = None

--- a/custom_components/eplucon/eplucon_api/DTO/HeatLoadingDTO.py
+++ b/custom_components/eplucon/eplucon_api/DTO/HeatLoadingDTO.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class HeatLoadingDTO:
+    heatloading_active: bool
+    configurations: dict[str, bool]

--- a/custom_components/eplucon/eplucon_api/eplucon_client.py
+++ b/custom_components/eplucon/eplucon_api/eplucon_client.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from .DTO.CommonInfoDTO import CommonInfoDTO
 from .DTO.DeviceDTO import DeviceDTO
 from .DTO.RealtimeInfoDTO import RealtimeInfoDTO
+from .DTO.HeatLoadingDTO import HeatLoadingDTO
 
 BASE_URL = "https://portaal.eplucon.nl/api/v2"
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -56,6 +57,17 @@ class EpluconApi:
             realtime_info = RealtimeInfoDTO(common=common_info, heatpump=heatpump_info)
 
             return realtime_info
+
+    async def get_heatpump_heatloading_status(self, module_id: int) -> dict:
+        url = f"{self._base}/econtrol/modules/{module_id}/heatloading_status"
+        _LOGGER.debug(f"Eplucon Get heatpump heatloading status for {module_id}: {url}")
+
+        async with self._session.get(url, headers=self._headers) as response:
+            data = await response.json()
+            self.validate_response(data)
+
+            heatloading_status = HeatLoadingDTO(**data['data'])
+            return heatloading_status
 
     @staticmethod
     def validate_response(response: Any) -> None:

--- a/custom_components/eplucon/eplucon_api/eplucon_client_mock.py
+++ b/custom_components/eplucon/eplucon_api/eplucon_client_mock.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from .DTO.CommonInfoDTO import CommonInfoDTO
 from .DTO.DeviceDTO import DeviceDTO
 from .DTO.RealtimeInfoDTO import RealtimeInfoDTO
+from .DTO.HeatLoadingDTO import HeatLoadingDTO
 
 BASE_URL = "https://koenhendriks.com/eplucon"
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -56,6 +57,18 @@ class EpluconApi:
             realtime_info = RealtimeInfoDTO(common=common_info, heatpump=heatpump_info)
 
             return realtime_info
+
+    async def get_heatpump_heatloading_status(self, module_id: int) -> dict:
+        url = f"{self._base}/econtrol/modules/{module_id}/heatloading_status.json"
+        _LOGGER.debug(f"Eplucon Get heatpump heatloading status for {module_id}: {url}")
+
+        async with self._session.get(url, headers=self._headers) as response:
+            data = await response.json()
+            self.validate_response(data)
+
+            heatloading_status = HeatLoadingDTO(**data['data'])
+            return heatloading_status
+
 
     @staticmethod
     def validate_response(response: Any) -> None:

--- a/custom_components/eplucon/sensor.py
+++ b/custom_components/eplucon/sensor.py
@@ -393,6 +393,27 @@ exists_fn=lambda device: device.realtime_info is not None and device.realtime_in
         exists_fn=lambda device: device.realtime_info is not None and device.realtime_info.common is not None and device.realtime_info.common.operation_mode is not None,
     ),
     EpluconSensorEntityDescription(
+        key="heatloading_active",
+        name="Heatloading Active",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda device: device.heatloading_status.heatloading_active,
+        exists_fn=lambda device: device.heatloading_status is not None and device.heatloading_status.heatloading_active is not None,
+    ),
+    EpluconSensorEntityDescription(
+        key="domestic_hot_water",
+        name="Domestic Hot Water",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda device: device.heatloading_status.configurations["domestic_hot_water"],
+        exists_fn=lambda device: device.heatloading_status is not None and device.heatloading_status.configurations is not None and "domestic_hot_water" in device.heatloading_status.configurations,
+    ),
+    EpluconSensorEntityDescription(
+        key="heatloading_for_heating",
+        name="Heatloading for Heating",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda device: device.heatloading_status.configurations["domestic_hot_water"],
+        exists_fn=lambda device: device.heatloading_status is not None and device.heatloading_status.configurations is not None and "heatloading_for_heating" in device.heatloading_status.configurations,
+    ),
+    EpluconSensorEntityDescription(
         key="operation_mode_text",
         name="Operation Mode Text",
         device_class=SensorDeviceClass.ENUM,


### PR DESCRIPTION
The Eplucon API allows requesting the heatloading status for a module resulting in the heatloading_active, domestic_hot_waterheat, loading_for_heating booleans. These results are added to the home assistant sensor.