### PR TITLE
Change import_energy and export_energy types to Union

### DIFF
--- a/custom_components/eplucon/eplucon_api/DTO/CommonInfoDTO.py
+++ b/custom_components/eplucon/eplucon_api/DTO/CommonInfoDTO.py
@@ -14,8 +14,8 @@ class CommonInfoDTO:
     heating_out_temperature: Union[float, str]
     energy_usage: int
     energy_delivered: int
-    import_energy: int
-    export_energy: int
+    import_energy: Union[float, str]
+    export_energy: Union[float, str]
     ww_temperature: Union[float, str]
     ww_temperature_configured: float
     brine_pressure: Union[float, str]


### PR DESCRIPTION
Fixes:

`Logger: homeassistant.config_entries
Source: config_entries.py:762
First occurred: 13:04:13 (2 occurrences)
Last logged: 17:52:21

Error setting up entry Eplucon for eplucon
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 762, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/eplucon/__init__.py", line 97, in async_setup_entry
    await register_devices(devices, entry, hass)
  File "/config/custom_components/eplucon/__init__.py", line 189, in register_devices
    device = await device_dict_to_dto(device)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/eplucon/__init__.py", line 76, in device_dict_to_dto
    device = from_dict(data_class=DeviceDTO, data=device)
  File "/usr/local/lib/python3.13/site-packages/dacite/core.py", line 69, in from_dict
    value = _build_value(type_=field_type, data=data[key], config=config)
  File "/usr/local/lib/python3.13/site-packages/dacite/core.py", line 103, in _build_value
    data = _build_value_for_union(union=type_, data=data, config=config)
  File "/usr/local/lib/python3.13/site-packages/dacite/core.py", line 121, in _build_value_for_union
    return _build_value(type_=types[0], data=data, config=config)
  File "/usr/local/lib/python3.13/site-packages/dacite/core.py", line 107, in _build_value
    data = from_dict(data_class=type_, data=data, config=config)
  File "/usr/local/lib/python3.13/site-packages/dacite/core.py", line 69, in from_dict
    value = _build_value(type_=field_type, data=data[key], config=config)
  File "/usr/local/lib/python3.13/site-packages/dacite/core.py", line 107, in _build_value
    data = from_dict(data_class=type_, data=data, config=config)
  File "/usr/local/lib/python3.13/site-packages/dacite/core.py", line 74, in from_dict
    raise WrongTypeError(field_path=field.name, field_type=field_type, value=value)
dacite.exceptions.WrongTypeError: wrong value type for field "realtime_info.common.import_energy" - should be "int" instead of value "15136.84" of type "float" `