### PR TITLE
Add support for zone controllers and control panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+* Support for `zones_system_controller` modules (th-TOUCH). Each regulation zone / control panel is exposed as its own Home Assistant device with read-only sensors: current temperature, target temperature, humidity, battery, signal strength, mode and regulation direction, plus a "Call for Heat" binary sensor. The target temperature cannot be updated within Home Assistant yet.
+
 ## [1.5.1](https://github.com/koenhendriks/ha-eplucon/releases/1.5.1) - 2026-01-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
-* Support for `zones_system_controller` modules (th-TOUCH). Each regulation zone / control panel is exposed as its own Home Assistant device with read-only sensors: current temperature, target temperature, humidity, battery, signal strength, mode and regulation direction, plus a "Call for Heat" binary sensor. The target temperature cannot be updated within Home Assistant yet.
+* Support for `zones_system_controller` modules (th-TOUCH). Each regulation zone / control panel is exposed as its own Home Assistant device with read-only sensors: current temperature, target temperature, humidity, battery, signal strength, mode and regulation direction, plus a "Call for Heat" binary sensor. Zone entities are named after their zone (`sensor.woonkamer_temperature`), and become unavailable when the zone drops out of the API rather than reporting a stale value. The target temperature cannot be updated within Home Assistant yet.
+* Tests for the zones endpoint: `raw_data` parsing, the documented HTTP 406 path, and zone entity naming and availability.
 
 ## [1.5.1](https://github.com/koenhendriks/ha-eplucon/releases/1.5.1) - 2026-01-27
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This custom integration allows you to integrate your Eplucon devices into Home A
 ## Features
 
 - Monitor indoor temperature, vent RPM, brine circulation pump, and more in real-time.
+- Expose per-zone control panels of a zone controller (th-TOUCH) as devices, with
+  temperature, humidity, battery, signal and call-for-heat sensors (read-only).
 - Automatically update sensor data using Home Assistant's update coordinator.
 
 ## Installation
@@ -53,6 +55,22 @@ This integration provides all available sensors that can be retrieved from the [
 - **Heating Status** - if applicable
 
 These sensors are automatically created based on the real-time information available from your Eplucon device.
+
+### Zone control panels (th-TOUCH)
+
+If your installation includes a zone controller (`zones_system_controller`), each
+regulation zone / room is added as its own device with read-only entities:
+
+- **Temperature** (°C) and **Target Temperature** (°C)
+- **Humidity** (%)
+- **Battery** (%) and **Signal Strength** (%) — diagnostic
+- **Mode** and **Regulation** (heating/cooling) — diagnostic
+- **Call for Heat** — binary sensor (the zone relay state)
+
+These use the same API token; no extra credentials are required. Setting a zone's
+target temperature from Home Assistant is **not** supported: the Eplucon public API
+is read-only for zones, and the portal's write path needs a separate web login.
+See [`docs/zones-api.md`](docs/zones-api.md) for the full API investigation.
 
 ### Screenshot
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ regulation zone / room is added as its own device with read-only entities:
 - **Mode** and **Regulation** (heating/cooling) — diagnostic
 - **Call for Heat** — binary sensor (the zone relay state)
 
+Entities are named after their zone, so a zone called *Woonkamer* yields
+`sensor.woonkamer_temperature`, `sensor.woonkamer_humidity` and so on. A zone
+that drops out of the API (flat control-panel battery, lost wireless link) is
+reported as unavailable rather than as a zero or an `off`.
+
 These use the same API token; no extra credentials are required. Setting a zone's
 target temperature from Home Assistant is **not** supported: the Eplucon public API
 is read-only for zones, and the portal's write path needs a separate web login.

--- a/custom_components/eplucon/__init__.py
+++ b/custom_components/eplucon/__init__.py
@@ -118,7 +118,21 @@ async def _update_zone_controller(client, device: DeviceDTO, hass: HomeAssistant
     else:
         last_good = hass.data[DOMAIN]["last_good_devices"].get(device.id)
         if last_good:
+            _LOGGER.warning(
+                "No zones returned for controller %s, keeping last known values",
+                device.id,
+            )
             device = last_good
+        else:
+            # Entities are built at platform setup, so with nothing to fall
+            # back on this controller gets no zone entities at all until the
+            # integration is reloaded. Say so rather than finish setup quietly.
+            _LOGGER.warning(
+                "No zones returned for controller %s and no previously known "
+                "zones; no zone entities will be created until the integration "
+                "is reloaded",
+                device.id,
+            )
 
     return device
 

--- a/custom_components/eplucon/__init__.py
+++ b/custom_components/eplucon/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 import asyncio
+import dataclasses
 from datetime import timedelta
 from typing import Dict
 
@@ -20,6 +21,8 @@ from .const import (
     EPLUCON_PORTAL_URL,
     MANUFACTURER,
     SUPPORTED_TYPES,
+    HEAT_PUMP_TYPES,
+    ZONE_CONTROLLER_TYPES,
 )
 from .eplucon_api.eplucon_client import (
     EpluconApi,
@@ -77,6 +80,89 @@ async def device_dict_to_dto(device: DeviceDTO | dict) -> DeviceDTO:
     return device
 
 
+async def _update_heat_pump(client, device: DeviceDTO, hass: HomeAssistant) -> DeviceDTO:
+    """Fetch heat pump realtime + heatloading data, with last-good fallback."""
+    realtime_info = await fetch_with_retry(client.get_realtime_info, device.id)
+    _LOGGER.debug("Realtime info for %s: %s", device.id, realtime_info)
+
+    heatloading_status = await fetch_with_retry(
+        client.get_heatpump_heatloading_status, device.id
+    )
+    _LOGGER.debug("Heatloading status for %s: %s", device.id, heatloading_status)
+
+    # Validate before overwriting
+    if is_valid_realtime_info(realtime_info):
+        device.realtime_info = realtime_info
+        device.heatloading_status = heatloading_status
+        hass.data[DOMAIN]["last_good_devices"][device.id] = device
+    else:
+        _LOGGER.warning(
+            "Invalid realtime data for device %s, keeping last known values",
+            device.id,
+        )
+        last_good = hass.data[DOMAIN]["last_good_devices"].get(device.id)
+        if last_good:
+            device = last_good
+
+    return device
+
+
+async def _update_zone_controller(client, device: DeviceDTO, hass: HomeAssistant) -> DeviceDTO:
+    """Fetch the regulation zones for a zones_system_controller module."""
+    zones = await fetch_with_retry(client.get_zones, device.id)
+    _LOGGER.debug("Fetched %d zones for %s", len(zones or []), device.id)
+
+    if zones:
+        device.zones = zones
+        hass.data[DOMAIN]["last_good_devices"][device.id] = device
+    else:
+        last_good = hass.data[DOMAIN]["last_good_devices"].get(device.id)
+        if last_good:
+            device = last_good
+
+    return device
+
+
+def _device_id(device) -> object:
+    """Return the module id from a stored dict or a DeviceDTO."""
+    return device["id"] if isinstance(device, dict) else device.id
+
+
+async def _ensure_supported_devices(hass: HomeAssistant, entry: ConfigEntry, client) -> None:
+    """Merge in supported modules missing from the stored config entry.
+
+    Older versions only stored heat_pump modules, so zone controllers added
+    to an account (or supported by a newer release) never appeared. Re-fetch
+    the module list at setup and add any supported module we don't have yet.
+    """
+    try:
+        fetched = await client.get_devices()
+    except Exception:  # network/API hiccup: keep the stored list, try again next start
+        _LOGGER.warning("Could not refresh Eplucon module list at setup", exc_info=True)
+        return
+
+    existing = list(entry.data.get("devices", []))
+    existing_ids = {_device_id(d) for d in existing}
+
+    missing = [
+        dataclasses.asdict(dev)
+        for dev in fetched
+        if dev.type in SUPPORTED_TYPES and dev.id not in existing_ids
+    ]
+
+    if not missing:
+        return
+
+    _LOGGER.info(
+        "Adding %d newly supported Eplucon module(s) to the config entry: %s",
+        len(missing),
+        [(d["id"], d["type"]) for d in missing],
+    )
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, "devices": existing + missing}
+    )
+
+
 # ----------------------------
 # Setup entry
 # ----------------------------
@@ -85,7 +171,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Eplucon from a config entry."""
     api_token = entry.data["api_token"]
     api_endpoint = entry.data.get("api_endpoint", BASE_URL)
-    devices = entry.data["devices"]
 
     session = async_get_clientsession(hass)
     client = EpluconApi(api_token, api_endpoint, session)
@@ -93,6 +178,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Store last known good devices
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault("last_good_devices", {})
+
+    # Pick up modules (e.g. zone controllers) not present in an older entry.
+    await _ensure_supported_devices(hass, entry, client)
+    devices = entry.data["devices"]
 
     await register_devices(devices, entry, hass)
 
@@ -104,46 +193,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for entry_device in entry.data["devices"]:
                 device = await device_dict_to_dto(entry_device)
 
-                if device.type not in SUPPORTED_TYPES:
-                    continue
-
                 _LOGGER.debug(
-                    "Updating device %s (%s)",
+                    "Updating device %s (%s, type=%s)",
                     device.name,
                     device.id,
+                    device.type,
                 )
 
-                realtime_info = await fetch_with_retry(
-                    client.get_realtime_info, device.id
-                )
-                _LOGGER.debug(
-                    "Realtime info for %s: %s",
-                    device.id,
-                    realtime_info,
-                )
-
-                heatloading_status = await fetch_with_retry(
-                    client.get_heatpump_heatloading_status, device.id
-                )
-                _LOGGER.debug(
-                    "Heatloading status for %s: %s",
-                    device.id,
-                    heatloading_status,
-                )
-
-                # Validate before overwriting
-                if is_valid_realtime_info(realtime_info):
-                    device.realtime_info = realtime_info
-                    device.heatloading_status = heatloading_status
-                    hass.data[DOMAIN]["last_good_devices"][device.id] = device
+                if device.type in HEAT_PUMP_TYPES:
+                    device = await _update_heat_pump(client, device, hass)
+                elif device.type in ZONE_CONTROLLER_TYPES:
+                    device = await _update_zone_controller(client, device, hass)
                 else:
-                    _LOGGER.warning(
-                        "Invalid realtime data for device %s, keeping last known values",
-                        device.id,
-                    )
-                    last_good = hass.data[DOMAIN]["last_good_devices"].get(device.id)
-                    if last_good:
-                        device = last_good
+                    continue
 
                 updated_devices.append(device)
 

--- a/custom_components/eplucon/binary_sensor.py
+++ b/custom_components/eplucon/binary_sensor.py
@@ -8,8 +8,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MANUFACTURER, BINARY_SENSORS
+from .const import (
+    DOMAIN,
+    MANUFACTURER,
+    BINARY_SENSORS,
+    ZONE_BINARY_SENSORS,
+    ZONE_CONTROLLER_TYPES,
+)
 from .eplucon_api.DTO.DeviceDTO import DeviceDTO
+from .zone_entity import EpluconZoneEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +31,7 @@ async def async_setup_entry(
 
     await coordinator.async_config_entry_first_refresh()
 
-    entities: list[EpluconBinarySensorEntity] = []
+    entities: list[BinarySensorEntity] = []
 
     for device in coordinator.data:
         if isinstance(device, dict):
@@ -38,8 +45,28 @@ async def async_setup_entry(
                 EpluconBinarySensorEntity(coordinator, device, description)
             )
 
+        # Per-zone binary sensors for zone controllers
+        if device.type in ZONE_CONTROLLER_TYPES and device.zones:
+            for zone in device.zones:
+                for description in ZONE_BINARY_SENSORS:
+                    if description.exists_fn(zone):
+                        entities.append(
+                            EpluconZoneBinarySensorEntity(coordinator, device, zone, description)
+                        )
+
     _LOGGER.debug("Adding %d binary sensor entities", len(entities))
     async_add_entities(entities)
+
+
+class EpluconZoneBinarySensorEntity(EpluconZoneEntity, BinarySensorEntity):
+    """A read-only binary sensor for a single regulation zone."""
+
+    @property
+    def is_on(self) -> bool:
+        zone = self.zone
+        if zone is None:
+            return False
+        return bool(self.entity_description.value_fn(zone))
 
 
 class EpluconBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/eplucon/const.py
+++ b/custom_components/eplucon/const.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     UnitOfPower,
     REVOLUTIONS_PER_MINUTE,
     PERCENTAGE,
+    EntityCategory,
 )
 
 from typing import Any
@@ -31,7 +32,11 @@ DOMAIN = "eplucon"
 MANUFACTURER = "Eplucon"
 PLATFORMS = ["sensor", "binary_sensor"]
 EPLUCON_PORTAL_URL = "https://portaal.eplucon.nl/"
-SUPPORTED_TYPES = ["heat_pump"]
+
+# Module types this integration knows how to handle.
+HEAT_PUMP_TYPES = ["heat_pump"]
+ZONE_CONTROLLER_TYPES = ["zones_system_controller"]
+SUPPORTED_TYPES = HEAT_PUMP_TYPES + ZONE_CONTROLLER_TYPES
 
 
 
@@ -236,3 +241,98 @@ for s in FRIENDLY_TEXT_SENSOR_DEFS:
 
 SENSORS = tuple(sensor_list)
 BINARY_SENSORS = tuple(binary_sensor_list)
+
+
+# ------------------------------------------------------------------------------------
+# Zone (control panel) sensor definitions
+#
+# These operate on a ZoneDTO (not a DeviceDTO). Read-only: temperature, humidity,
+# battery and signal are pulled from the zones API. See docs/zones-api.md.
+# ------------------------------------------------------------------------------------
+
+def _zone_number(value):
+    """Coerce a zone value to float, or None when missing."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+ZONE_SENSORS = (
+    EpluconSensorEntityDescription(
+        key="zone_temperature",
+        name="Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda zone: _zone_number(zone.current_temperature),
+        exists_fn=lambda zone: zone.current_temperature is not None,
+    ),
+    EpluconSensorEntityDescription(
+        key="zone_target_temperature",
+        name="Target Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda zone: _zone_number(zone.set_temperature),
+        exists_fn=lambda zone: zone.set_temperature is not None,
+    ),
+    EpluconSensorEntityDescription(
+        key="zone_humidity",
+        name="Humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda zone: _zone_number(zone.humidity),
+        exists_fn=lambda zone: zone.humidity is not None,
+    ),
+    EpluconSensorEntityDescription(
+        key="zone_battery",
+        name="Battery",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda zone: _zone_number(zone.battery_level),
+        exists_fn=lambda zone: zone.battery_level is not None,
+    ),
+    # Signal strength here is a 0-100 scale, not dBm, so no SIGNAL_STRENGTH
+    # device class (which would imply dBm). Exposed as a plain diagnostic %.
+    EpluconSensorEntityDescription(
+        key="zone_signal_strength",
+        name="Signal Strength",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda zone: _zone_number(zone.signal_strength),
+        exists_fn=lambda zone: zone.signal_strength is not None,
+    ),
+    # Plain text (no ENUM device class): the value sets are open/undocumented,
+    # and an ENUM sensor raises if a value is outside a declared options list.
+    EpluconSensorEntityDescription(
+        key="zone_mode",
+        name="Mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda zone: zone.mode,
+        exists_fn=lambda zone: zone.mode is not None,
+    ),
+    EpluconSensorEntityDescription(
+        key="zone_algorithm",
+        name="Regulation",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda zone: zone.algorithm,
+        exists_fn=lambda zone: zone.algorithm is not None,
+    ),
+)
+
+ZONE_BINARY_SENSORS = (
+    EpluconBinarySensorEntityDescription(
+        key="zone_relay",
+        name="Call for Heat",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=lambda zone: str(zone.relay_state).lower() == "on",
+        exists_fn=lambda zone: zone.relay_state is not None,
+    ),
+)

--- a/custom_components/eplucon/eplucon_api/DTO/DeviceDTO.py
+++ b/custom_components/eplucon/eplucon_api/DTO/DeviceDTO.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 from .RealtimeInfoDTO import RealtimeInfoDTO
 from .HeatLoadingDTO import HeatLoadingDTO
+from .ZoneDTO import ZoneDTO
 
 
 @dataclass
@@ -12,3 +13,4 @@ class DeviceDTO:
     type: str
     realtime_info: Optional[RealtimeInfoDTO] = None
     heatloading_status: Optional[HeatLoadingDTO] = None
+    zones: Optional[List[ZoneDTO]] = None

--- a/custom_components/eplucon/eplucon_api/DTO/ZoneDTO.py
+++ b/custom_components/eplucon/eplucon_api/DTO/ZoneDTO.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import Optional, Union
+
+
+@dataclass
+class ZoneDTO:
+    """A single regulation zone / control panel of a zones_system_controller.
+
+    Top-level fields come straight from the /zones API response; the remaining
+    fields are extracted from the (double-encoded) ``raw_data`` JSON string.
+    See docs/zones-api.md for the full field reference.
+    """
+
+    id: int
+    name: str
+    mode: Optional[str] = None
+    set_temperature: Union[float, str, None] = None
+    current_temperature: Union[float, str, None] = None
+
+    # Extracted from raw_data.zone
+    humidity: Optional[float] = None
+    battery_level: Optional[float] = None
+    signal_strength: Optional[float] = None
+    relay_state: Optional[str] = None        # "on" / "off"
+    algorithm: Optional[str] = None          # "heating" / "cooling"
+    actuators_open: Optional[int] = None
+    zone_state: Optional[str] = None         # e.g. "noAlarm"

--- a/custom_components/eplucon/eplucon_api/eplucon_client.py
+++ b/custom_components/eplucon/eplucon_api/eplucon_client.py
@@ -13,6 +13,10 @@ from .DTO.ZoneDTO import ZoneDTO
 
 BASE_URL = "https://portaal.eplucon.nl/api/v2"
 
+# The zones endpoint answers 406 "Account is not a zone-controller" for a
+# module that has no zones. See docs/zones-api.md section 2.
+HTTP_NOT_ACCEPTABLE = 406
+
 _LOGGER = logging.getLogger(__package__)
 
 
@@ -39,6 +43,9 @@ class EpluconApi:
             raise RuntimeError("aiohttp ClientSession is required")
 
         self._session = session
+        # Modules the zones endpoint has already rejected with a 406, so the
+        # warning is logged once instead of on every coordinator refresh.
+        self._not_a_zone_controller: set[int] = set()
         self._headers = {
             "Accept": "application/json",
             "Cache-Control": "no-cache",
@@ -111,15 +118,68 @@ class EpluconApi:
         _LOGGER.debug("Fetching zones for %s: %s", module_id, url)
 
         async with self._session.get(url, headers=self._headers) as response:
-            data = await response.json()
+            status = response.status
+            # This is the first endpoint with a documented non-200 path, and
+            # the error body's content type isn't documented, so don't let
+            # aiohttp reject it before we can read the message out of it.
+            try:
+                data = await response.json(content_type=None)
+            except (aiohttp.ClientError, ValueError):
+                data = None
 
-        _LOGGER.debug("Zones raw response for %s: %s", module_id, data)
+        _LOGGER.debug(
+            "Zones raw response for %s (HTTP %s): %s", module_id, status, data
+        )
+
+        message = data.get("message") if isinstance(data, dict) else None
+        error_code = self._error_code(data)
+
+        # A 406 is permanent: this module will never have zones. Retrying it
+        # or failing the whole coordinator refresh over it would both be
+        # disproportionate, so report "no zones" and warn once.
+        if HTTP_NOT_ACCEPTABLE in (status, error_code):
+            if module_id not in self._not_a_zone_controller:
+                self._not_a_zone_controller.add(module_id)
+                _LOGGER.warning(
+                    "Eplucon module %s does not expose zones, no zone entities "
+                    "will be created for it: %s",
+                    module_id,
+                    message or f"HTTP {HTTP_NOT_ACCEPTABLE} from {url}",
+                )
+            return []
+
+        if status != 200:
+            if status in (401, 403):
+                raise ApiAuthError(
+                    f"Not authorized to read zones of module {module_id} "
+                    f"(HTTP {status})"
+                )
+            raise ApiError(
+                f"Zones request for module {module_id} failed with HTTP {status}"
+                + (f": {message}" if message else "")
+            )
+
         self._validate_response(data)
 
+        if error_code is not None and error_code != 200:
+            raise ApiError(
+                f"Zones request for module {module_id} returned error_code "
+                f"{error_code}" + (f": {message}" if message else "")
+            )
+
+        items = data.get("data")
+        if not isinstance(items, list):
+            raise ApiError(
+                f"Zones response for module {module_id} has no 'data' list: {items!r}"
+            )
+
         zones: list[ZoneDTO] = []
-        for item in data.get("data", []):
+        for item in items:
             try:
                 zones.append(self._parse_zone(item))
+            except ValueError as err:
+                # An entry we can't identify; no stacktrace needed for it.
+                _LOGGER.warning("Skipping unusable zone entry: %s", err)
             except Exception:
                 _LOGGER.exception("Failed to parse zone DTO: %s", item)
 
@@ -127,10 +187,44 @@ class EpluconApi:
         return zones
 
     @staticmethod
+    def _error_code(data: Any) -> int | None:
+        """Return the response's error_code as an int, or None if unusable."""
+        if not isinstance(data, dict):
+            return None
+
+        raw = data.get("error_code")
+        if raw is None:
+            return None
+
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
     def _parse_zone(item: dict) -> ZoneDTO:
-        """Build a ZoneDTO from one /zones entry, enriching from raw_data."""
+        """Build a ZoneDTO from one /zones entry, enriching from raw_data.
+
+        Raises ValueError for an entry that cannot be identified; anything the
+        enrichment step can't make sense of is left as None rather than losing
+        the top-level fields with it.
+        """
+        if not isinstance(item, dict):
+            raise ValueError(f"zone entry is not an object: {item!r}")
+
+        raw_id = item.get("id")
+        if raw_id is None:
+            raise ValueError(f"zone entry has no id: {item}")
+
+        try:
+            zone_id = int(raw_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"zone entry has a non-numeric id {raw_id!r}: {item}"
+            ) from None
+
         zone = ZoneDTO(
-            id=int(item["id"]),
+            id=zone_id,
             name=item.get("name"),
             mode=item.get("mode"),
             set_temperature=item.get("set_temperature"),
@@ -147,8 +241,15 @@ class EpluconApi:
             _LOGGER.debug("Zone %s has unparseable raw_data", zone.id)
             return zone
 
-        z = parsed.get("zone", {}) if isinstance(parsed, dict) else {}
-        flags = z.get("flags", {}) if isinstance(z, dict) else {}
+        # Both keys can be present with a JSON null, so a `.get(key, {})`
+        # default is not enough: check what actually came back.
+        z = parsed.get("zone") if isinstance(parsed, dict) else None
+        if not isinstance(z, dict):
+            z = {}
+
+        flags = z.get("flags")
+        if not isinstance(flags, dict):
+            flags = {}
 
         zone.humidity = z.get("humidity")
         zone.battery_level = z.get("batteryLevel")

--- a/custom_components/eplucon/eplucon_api/eplucon_client.py
+++ b/custom_components/eplucon/eplucon_api/eplucon_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import aiohttp
+import json
 import logging
 from typing import Any
 
@@ -8,6 +9,7 @@ from .DTO.CommonInfoDTO import CommonInfoDTO
 from .DTO.DeviceDTO import DeviceDTO
 from .DTO.RealtimeInfoDTO import RealtimeInfoDTO
 from .DTO.HeatLoadingDTO import HeatLoadingDTO
+from .DTO.ZoneDTO import ZoneDTO
 
 BASE_URL = "https://portaal.eplucon.nl/api/v2"
 
@@ -98,6 +100,65 @@ class EpluconApi:
         self._validate_response(data)
 
         return HeatLoadingDTO(**data["data"])
+
+    async def get_zones(self, module_id: int) -> list[ZoneDTO]:
+        """Fetch the regulation zones / control panels of a zone controller.
+
+        Only valid for modules of type ``zones_system_controller``; other
+        module types return HTTP 406. See docs/zones-api.md.
+        """
+        url = f"{self._base}/econtrol/modules/{module_id}/zones"
+        _LOGGER.debug("Fetching zones for %s: %s", module_id, url)
+
+        async with self._session.get(url, headers=self._headers) as response:
+            data = await response.json()
+
+        _LOGGER.debug("Zones raw response for %s: %s", module_id, data)
+        self._validate_response(data)
+
+        zones: list[ZoneDTO] = []
+        for item in data.get("data", []):
+            try:
+                zones.append(self._parse_zone(item))
+            except Exception:
+                _LOGGER.exception("Failed to parse zone DTO: %s", item)
+
+        _LOGGER.debug("Parsed %d zones for module %s", len(zones), module_id)
+        return zones
+
+    @staticmethod
+    def _parse_zone(item: dict) -> ZoneDTO:
+        """Build a ZoneDTO from one /zones entry, enriching from raw_data."""
+        zone = ZoneDTO(
+            id=int(item["id"]),
+            name=item.get("name"),
+            mode=item.get("mode"),
+            set_temperature=item.get("set_temperature"),
+            current_temperature=item.get("current_temperature"),
+        )
+
+        raw = item.get("raw_data")
+        if not raw:
+            return zone
+
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+        except (ValueError, TypeError):
+            _LOGGER.debug("Zone %s has unparseable raw_data", zone.id)
+            return zone
+
+        z = parsed.get("zone", {}) if isinstance(parsed, dict) else {}
+        flags = z.get("flags", {}) if isinstance(z, dict) else {}
+
+        zone.humidity = z.get("humidity")
+        zone.battery_level = z.get("batteryLevel")
+        zone.signal_strength = z.get("signalStrength")
+        zone.actuators_open = z.get("actuatorsOpen")
+        zone.zone_state = z.get("zoneState")
+        zone.relay_state = flags.get("relayState")
+        zone.algorithm = flags.get("algorithm")
+
+        return zone
 
     @staticmethod
     def _validate_response(response: Any) -> None:

--- a/custom_components/eplucon/sensor.py
+++ b/custom_components/eplucon/sensor.py
@@ -10,9 +10,17 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.typing import StateType
 from typing import Any
 
-from .const import DOMAIN, MANUFACTURER, SENSORS, EpluconSensorEntityDescription
+from .const import (
+    DOMAIN,
+    MANUFACTURER,
+    SENSORS,
+    ZONE_SENSORS,
+    ZONE_CONTROLLER_TYPES,
+    EpluconSensorEntityDescription,
+)
 
 from .eplucon_api.DTO.DeviceDTO import DeviceDTO
+from .zone_entity import EpluconZoneEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,8 +48,28 @@ async def async_setup_entry(
             if description.exists_fn(device):
                 entities.append(EpluconSensorEntity(coordinator, device, description))
 
+        # Per-zone sensors for zone controllers
+        if device.type in ZONE_CONTROLLER_TYPES and device.zones:
+            for zone in device.zones:
+                for description in ZONE_SENSORS:
+                    if description.exists_fn(zone):
+                        entities.append(
+                            EpluconZoneSensorEntity(coordinator, device, zone, description)
+                        )
+
     _LOGGER.debug("Adding %d sensor entities", len(entities))
     async_add_entities(entities)
+
+
+class EpluconZoneSensorEntity(EpluconZoneEntity, SensorEntity):
+    """A read-only sensor for a single regulation zone / control panel."""
+
+    @property
+    def native_value(self) -> StateType:
+        zone = self.zone
+        if zone is None:
+            return None
+        return self.entity_description.value_fn(zone)
 
 
 class EpluconSensorEntity(CoordinatorEntity, SensorEntity):

--- a/custom_components/eplucon/zone_entity.py
+++ b/custom_components/eplucon/zone_entity.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from dacite import from_dict
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
@@ -20,19 +19,28 @@ class EpluconZoneEntity(CoordinatorEntity):
     linked to the controller module via ``via_device``.
     """
 
+    # Every zone repeats the same entity descriptions, so the entity name on
+    # its own ("Temperature") is not unique across zones. Let HA prefix the
+    # zone device name: sensor.woonkamer_temperature rather than
+    # sensor.temperature_3, whose numbering depends on the order the API
+    # happened to return the zones in when the registry entries were created.
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator, device: DeviceDTO, zone: ZoneDTO, entity_description) -> None:
         super().__init__(coordinator)
         self._module_id = device.id
         self._module_index = device.account_module_index
         self._zone_id = zone.id
         self._zone_name = zone.name
+        # The name comes from entity_description; setting _attr_name as well
+        # would only duplicate it.
         self.entity_description = entity_description
-        self._attr_name = entity_description.name
         self._attr_unique_id = f"{device.id}_zone_{zone.id}_{entity_description.key}"
 
         _LOGGER.debug(
-            "Created zone entity %s with unique_id %s",
-            self._attr_name,
+            "Created zone entity %s for zone %s with unique_id %s",
+            entity_description.name,
+            self._zone_name,
             self._attr_unique_id,
         )
 
@@ -40,14 +48,23 @@ class EpluconZoneEntity(CoordinatorEntity):
     def zone(self) -> Optional[ZoneDTO]:
         """Return the current ZoneDTO from the latest coordinator data."""
         for device in self.coordinator.data:
-            if isinstance(device, dict):
-                device = from_dict(data_class=DeviceDTO, data=device)
             if device.id != self._module_id or not device.zones:
                 continue
             for zone in device.zones:
                 if zone.id == self._zone_id:
                     return zone
         return None
+
+    @property
+    def available(self) -> bool:
+        """Report unavailable while the zone is missing from the data.
+
+        Without this a zone that drops out (dead control-panel battery, lost
+        wireless link) would read as a plain ``off`` on the binary sensors,
+        which is indistinguishable from the zone genuinely not calling for
+        heat.
+        """
+        return super().available and self.zone is not None
 
     @property
     def device_info(self) -> dict:

--- a/custom_components/eplucon/zone_entity.py
+++ b/custom_components/eplucon/zone_entity.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from dacite import from_dict
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .eplucon_api.DTO.DeviceDTO import DeviceDTO
+from .eplucon_api.DTO.ZoneDTO import ZoneDTO
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EpluconZoneEntity(CoordinatorEntity):
+    """Base for entities backed by a single zone of a zones controller.
+
+    Each zone is modelled as its own HA device (a room / control panel),
+    linked to the controller module via ``via_device``.
+    """
+
+    def __init__(self, coordinator, device: DeviceDTO, zone: ZoneDTO, entity_description) -> None:
+        super().__init__(coordinator)
+        self._module_id = device.id
+        self._module_index = device.account_module_index
+        self._zone_id = zone.id
+        self._zone_name = zone.name
+        self.entity_description = entity_description
+        self._attr_name = entity_description.name
+        self._attr_unique_id = f"{device.id}_zone_{zone.id}_{entity_description.key}"
+
+        _LOGGER.debug(
+            "Created zone entity %s with unique_id %s",
+            self._attr_name,
+            self._attr_unique_id,
+        )
+
+    @property
+    def zone(self) -> Optional[ZoneDTO]:
+        """Return the current ZoneDTO from the latest coordinator data."""
+        for device in self.coordinator.data:
+            if isinstance(device, dict):
+                device = from_dict(data_class=DeviceDTO, data=device)
+            if device.id != self._module_id or not device.zones:
+                continue
+            for zone in device.zones:
+                if zone.id == self._zone_id:
+                    return zone
+        return None
+
+    @property
+    def device_info(self) -> dict:
+        """Return per-zone device info, linked to the controller module."""
+        return {
+            "identifiers": {(DOMAIN, f"{self._module_index}_zone_{self._zone_id}")},
+            "name": self._zone_name,
+            "manufacturer": MANUFACTURER,
+            "model": "Zone control panel",
+            "via_device": (DOMAIN, self._module_index),
+        }

--- a/docs/zones-api.md
+++ b/docs/zones-api.md
@@ -1,0 +1,236 @@
+# Eplucon zones / control-panel API
+
+Notes on how the Eplucon portal (`https://portaal.eplucon.nl`) exposes
+"regulation zones" and their per-zone control panels (th-TOUCH /
+`zones_system_controller`), and how their target temperature is changed.
+
+Everything below was verified against a live production deployment on
+2026-07-13. Where a statement is inferred rather than directly
+observed, it is marked as such.
+
+## Summary
+
+There are two distinct surfaces with different auth models:
+
+| Purpose | Surface | Auth | State |
+|---|---|---|---|
+| **Read** zones (temperature, humidity, battery, …) | public API `/api/v2` | Bearer API token | documented in OpenAPI, stable |
+| **Write** zone target temperature | portal web route `/e-control/*` | web session cookie + CSRF | **undocumented**, used by the portal UI itself |
+
+The public documented API is **read-only** for zones. There is no `/api/v2`
+endpoint to set a zone's temperature — the portal front-end performs that write
+against a session-authenticated web route, not the token API. An HA integration
+that wants to actuate setpoints therefore needs the portal **username/password**
+in addition to the API token. (Posting the write with a Bearer token
+and no session returns `419 CSRF token mismatch`.)
+
+---
+
+## 1. Module discovery (public API)
+
+`GET /api/v2/econtrol/modules` — Bearer token.
+
+```json
+{
+  "auth": true,
+  "data": [
+    { "id": 1003355, "account_module_index": "1605d52f…", "name": "warmtepomp", "type": "heat_pump" },
+    { "id": 1003495, "account_module_index": "27b2a803…", "name": "Thtouch",    "type": "zones_system_controller" }
+  ],
+  "error_code": 200
+}
+```
+
+A zone controller has `type == "zones_system_controller"`. (The portal CSS also
+references a `zones_controller` type; only `zones_system_controller` was seen on
+this deployment.) Note the two identifiers per module:
+
+- `id` — integer module id, used in `/api/v2/econtrol/modules/{id}/…` read paths.
+- `account_module_index` — opaque hex string, used as a query parameter on the
+  `/e-control/*` **write** routes.
+
+Both are needed for full zone support.
+
+## 2. Reading zones (public API)
+
+`GET /api/v2/econtrol/modules/{moduleId}/zones` — Bearer token.
+
+Documented in the portal OpenAPI (`/docs/api.json`, operation `zones`).
+For a non-zone module it returns `406` with
+`message: "Account is not a zone-controller"`.
+
+```json
+{
+  "auth": true,
+  "data": [
+    {
+      "id": 3073,
+      "name": "Woonkamer",
+      "set_temperature": 20.6,
+      "mode": "constantTemp",
+      "current_temperature": 21.5,
+      "raw_data": "{…escaped JSON…}"
+    }
+  ],
+  "error_code": 200
+}
+```
+
+Per-zone top-level fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | int | **Portal** zone id (e.g. `3073`). Stable per zone. Used in `/e-control/zones/store/{id}`. |
+| `name` | string | Zone display name. |
+| `set_temperature` | number | Target temperature in °C (already divided by 10). |
+| `current_temperature` | number | Measured temperature in °C. |
+| `mode` | string | e.g. `constantTemp` (constant setpoint) or a schedule mode. |
+| `raw_data` | string | JSON-encoded string with the full th-TOUCH zone record (below). |
+
+The OpenAPI schema types these as `string`; in practice numeric fields arrive as
+JSON numbers. Treat them defensively (the existing client already coerces).
+
+### `raw_data` structure
+
+`raw_data` is a JSON **string** that must be parsed a second time. It carries the
+richer sensor data that is not in the top-level fields. Example (one zone):
+
+```jsonc
+{
+  "zone": {
+    "id": 9010,                 // th-TOUCH internal zone id (NOT the portal id 3073)
+    "parentId": 9002,
+    "time": "2026-07-13T19:38:55",
+    "duringChange": false,
+    "index": 0,
+    "currentTemperature": 215,  // ×10  → 21.5 °C
+    "setTemperature": 205,      // ×10  → 20.5 °C
+    "flags": {
+      "relayState": "on",       // "on" | "off" — call-for-heat / actuator relay
+      "minOneWindowOpen": false,
+      "algorithm": "cooling",   // "heating" | "cooling" — current regulation direction
+      "floorSensor": 0,
+      "humidityAlgorytm": 0,
+      "zoneExcluded": 0
+    },
+    "zoneState": "noAlarm",
+    "signalStrength": 73,       // wireless link, 0–100 (%). Inferred unit.
+    "batteryLevel": 92,         // %
+    "actuatorsOpen": 0,
+    "humidity": 69,             // % relative humidity
+    "visibility": true
+  },
+  "description": { "id": 9011, "parentId": 9010, "name": "Woonkamer", "styleId": 0, "styleIcon": "living_room", "duringChange": false },
+  "mode":        { "id": 9012, "parentId": 9010, "mode": "constantTemp", "constTempTime": 60, "setTemperature": 205, "scheduleIndex": 0 },
+  "schedule":    { "id": 9014, "parentId": 9010, "index": -1, "p0Days": ["1","1","1","1","1","0","0"], "p0Intervals": [{"start":1020,"stop":1380,"temp":205}], "p0SetbackTemp": 195, "p1Days": […], "p1Intervals": […], "p1SetbackTemp": 195 },
+  "actuators": [], "underfloor": {}, "windowsSensors": [], "additionalContacts": [], "color": "#a04515"
+}
+```
+
+Fields worth surfacing as HA entities:
+
+| Path in `raw_data` | Meaning | Unit |
+|---|---|---|
+| `zone.currentTemperature` / 10 | measured temperature | °C |
+| `zone.setTemperature` / 10 | target temperature | °C |
+| `zone.humidity` | relative humidity | % |
+| `zone.batteryLevel` | control-panel battery | % |
+| `zone.signalStrength` | wireless signal (unit inferred: %) | % |
+| `zone.flags.relayState` | call-for-heat / relay | `on`/`off` |
+| `zone.flags.algorithm` | regulation direction | `heating`/`cooling` |
+| `zone.flags.minOneWindowOpen` | any window open | bool |
+| `zone.actuatorsOpen` | open actuators count | int |
+| `zone.zoneState` | alarm state | `noAlarm`/… |
+
+**Temperature scaling:** the top-level `set_temperature`/`current_temperature`
+are in °C; the `raw_data` `*Temperature` values and the write `constant_temp`
+field are all **×10** (deci-degrees).
+
+**ID mapping** (needed to write — confirmed identical across all 4 zones):
+
+| Write field | Source |
+|---|---|
+| `zone_id`  | `raw_data.zone.id` |
+| `parent_id`| `raw_data.mode.parentId` (equals `zone.id` on this deployment) |
+| `mode_id`  | `raw_data.mode.id` |
+
+The portal zone id (`data[].id`, e.g. `3073`) is **not** used by the constant-temp
+write; it is only used by `/e-control/zones/store/{id}` (rename/icon config).
+
+## 3. Setting a zone's target temperature (portal web route)
+
+This is the endpoint the portal UI uses. It is **not** in the public OpenAPI.
+
+```
+POST /e-control/set_constant_temp?account_module_index={account_module_index}
+```
+
+**Auth / headers** (all required):
+
+- `Cookie: portaal_eplucon_session=…; XSRF-TOKEN=…` — from a logged-in web session.
+- `X-CSRF-TOKEN: {token}` — the CSRF token (from the `<meta name="csrf-token">`
+  tag of any authenticated portal page, or the decrypted `XSRF-TOKEN` cookie).
+- `X-Requested-With: XMLHttpRequest`
+
+**Body** — `multipart/form-data` (also accepts standard form encoding):
+
+| Field | Example | Meaning |
+|---|---|---|
+| `_token` | `QMIANr5B…` | CSRF token (same value as header). |
+| `active_schedule` | `0` | `0` = constant temp mode (override schedule). |
+| `mode` | `constantTemp` | Fixed for a setpoint override. |
+| `mode_id` | `9012` | `raw_data.mode.id`. |
+| `zone_id` | `9010` | `raw_data.zone.id`. |
+| `parent_id` | `9010` | `raw_data.mode.parentId`. |
+| `constant_temp` | `206` | **target °C × 10** (206 = 20.6 °C). |
+
+The portal front-end additionally sends `dataSerialize` (url-encoded copy) and
+`data` (JSON copy) of the same fields; these are redundant jQuery-serialize
+artifacts and are not required — a POST with only the seven fields above
+succeeds.
+
+**Range:** the UI slider is `min=50 max=350 step=1`, i.e. **5.0 – 35.0 °C** in
+0.1 °C steps.
+
+**Response:** HTTP `200`, body `1` on success. `419` + `CSRF token mismatch`
+if the session/CSRF is wrong.
+
+### Web login (to obtain the session)
+
+```
+GET  /login          → parse <meta name="csrf-token"> and hidden form fields
+POST /login          → form: _token, username, password, remember=1,
+                       plus honeypot fields echoed from the GET form
+                       (an empty name-honeypot input and a `valid_from` token)
+```
+
+On success the portal sets `portaal_eplucon_session` and `XSRF-TOKEN` cookies and
+redirects to `/e-control`. The login page also carries anti-spam honeypot fields
+(`my_name_*` left empty, and an encrypted `valid_from` value echoed back); a login
+succeeded in testing even without echoing `valid_from`, but echoing both is
+safest.
+
+> Note: `POST /api/v2/auth/login` (documented) returns an `access_token` that, on
+> this account, is **identical to the API token** and is a *token*, not a web
+> session — it does not carry the CSRF/session cookies the `/e-control/*` write
+> route requires.
+
+## 4. Other zone web routes seen (not needed for temperature control)
+
+- `GET  /e-control/zones` — the HTML zones page (source of the forms above).
+- `GET  /e-control/zones/ajax/refresh?account_module_index=…` — returns
+  `{ html: … }` used to refresh the tile grid.
+- `POST /e-control/zones/store/{portalZoneId}` — rename / icon / master config;
+  fields include `name`, `icon`, `is_master`, `description_id`, `internal_zone_id`.
+
+## 5. Implications for the HA integration
+
+- **Reads** (all sensors) work with the existing Bearer-token client — just add a
+  `get_zones(module_id)` call and parse `raw_data`.
+- **Writes** (climate setpoint) need a **separate session-based path**: portal
+  username + password, cookie jar, CSRF handling. This is a new dependency
+  (credentials beyond the API token) and should be optional — read-only zone
+  entities still work with only the token.
+- The write is inherently a cloud round-trip through the portal UI's own route;
+  it may be more fragile than the documented API (CSRF token rotation, session
+  expiry, login honeypot changes).

--- a/tests/test_zone_entity.py
+++ b/tests/test_zone_entity.py
@@ -1,0 +1,157 @@
+"""Tests for the naming and availability of zone-backed entities."""
+
+import pytest
+
+from custom_components.eplucon.binary_sensor import EpluconZoneBinarySensorEntity
+from custom_components.eplucon.const import (
+    DOMAIN,
+    ZONE_BINARY_SENSORS,
+    ZONE_SENSORS,
+)
+from custom_components.eplucon.eplucon_api.DTO.DeviceDTO import DeviceDTO
+from custom_components.eplucon.eplucon_api.DTO.ZoneDTO import ZoneDTO
+from custom_components.eplucon.sensor import EpluconZoneSensorEntity
+
+TEMPERATURE = next(d for d in ZONE_SENSORS if d.key == "zone_temperature")
+CALL_FOR_HEAT = next(d for d in ZONE_BINARY_SENSORS if d.key == "zone_relay")
+
+
+class FakeCoordinator:
+    """Enough of a DataUpdateCoordinator for CoordinatorEntity to work with."""
+
+    def __init__(self, data, last_update_success=True):
+        self.data = data
+        self.last_update_success = last_update_success
+
+
+def make_zone(zone_id=3073, name="Woonkamer", **overrides):
+    return ZoneDTO(
+        id=zone_id,
+        name=name,
+        current_temperature=overrides.pop("current_temperature", 21.5),
+        relay_state=overrides.pop("relay_state", "on"),
+        **overrides,
+    )
+
+
+def make_device(zones):
+    return DeviceDTO(
+        id=1, account_module_index="abc123", name="Controller",
+        type="zones_system_controller", zones=zones,
+    )
+
+
+def make_sensor(zones, description=TEMPERATURE, zone=None, last_update_success=True):
+    device = make_device(zones)
+    return EpluconZoneSensorEntity(
+        FakeCoordinator([device], last_update_success),
+        device,
+        zone or zones[0],
+        description,
+    )
+
+
+# ----------------------------
+# Naming (review item 1)
+# ----------------------------
+
+def test_zone_entity_defers_naming_to_the_device():
+    """HA prefixes the zone device name onto the entity id only when this is set.
+
+    Without it every zone contributes an entity literally named "Temperature",
+    and the registry disambiguates them as _2, _3, ... in API response order.
+    """
+    entity = make_sensor([make_zone()])
+
+    assert entity.has_entity_name is True
+    assert entity.name == "Temperature"
+    assert entity.device_info["name"] == "Woonkamer"
+
+
+def test_zone_entities_are_unique_per_zone():
+    zones = [make_zone(3073, "Woonkamer"), make_zone(3074, "Keuken")]
+
+    unique_ids = {
+        make_sensor(zones, description, zone).unique_id
+        for zone in zones
+        for description in (TEMPERATURE, CALL_FOR_HEAT)
+    }
+    assert len(unique_ids) == 4
+
+    identifiers = [
+        make_sensor(zones, TEMPERATURE, zone).device_info["identifiers"]
+        for zone in zones
+    ]
+    assert identifiers == [
+        {(DOMAIN, "abc123_zone_3073")},
+        {(DOMAIN, "abc123_zone_3074")},
+    ]
+
+
+def test_zone_device_links_back_to_the_controller():
+    info = make_sensor([make_zone()]).device_info
+
+    assert info["via_device"] == (DOMAIN, "abc123")
+
+
+# ----------------------------
+# Availability (review item 3)
+# ----------------------------
+
+def test_zone_entity_available_when_zone_is_present():
+    entity = make_sensor([make_zone()])
+
+    assert entity.available is True
+    assert entity.native_value == 21.5
+
+
+def test_zone_entity_unavailable_when_zone_vanishes():
+    """A dropped zone must not read as a valid value."""
+    zone = make_zone()
+    entity = make_sensor([zone])
+    entity.coordinator.data = [make_device([])]
+
+    assert entity.zone is None
+    assert entity.available is False
+
+
+def test_binary_sensor_does_not_report_off_for_a_vanished_zone():
+    """The misleading case: 'Call for Heat' off vs. the zone being gone."""
+    zone = make_zone(relay_state="on")
+    device = make_device([zone])
+    entity = EpluconZoneBinarySensorEntity(
+        FakeCoordinator([device]), device, zone, CALL_FOR_HEAT
+    )
+
+    assert entity.available is True
+    assert entity.is_on is True
+
+    entity.coordinator.data = [make_device([])]
+    assert entity.available is False
+
+
+@pytest.mark.parametrize("zones", [[], None])
+def test_zone_entity_unavailable_when_controller_has_no_zones(zones):
+    entity = make_sensor([make_zone()])
+    entity.coordinator.data = [make_device(zones)]
+
+    assert entity.available is False
+
+
+def test_zone_entity_unavailable_when_the_coordinator_failed():
+    """Availability composes with the coordinator's own state."""
+    entity = make_sensor([make_zone()], last_update_success=False)
+
+    assert entity.zone is not None
+    assert entity.available is False
+
+
+def test_zone_entity_ignores_other_modules():
+    entity = make_sensor([make_zone()])
+    other = DeviceDTO(
+        id=2, account_module_index="zzz", name="Other",
+        type="zones_system_controller", zones=[make_zone()],
+    )
+    entity.coordinator.data = [other]
+
+    assert entity.available is False

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -1,0 +1,264 @@
+"""Tests for the zones endpoint parsing and error handling."""
+
+import json
+
+import aiohttp
+import pytest
+
+from custom_components.eplucon.eplucon_api.eplucon_client import (
+    ApiAuthError,
+    ApiError,
+    EpluconApi,
+)
+
+# Trimmed from the sample in docs/zones-api.md; keeps every field the client
+# actually reads.
+RAW_DATA = {
+    "zone": {
+        "id": 9010,
+        "currentTemperature": 215,
+        "setTemperature": 205,
+        "flags": {"relayState": "on", "algorithm": "cooling"},
+        "zoneState": "noAlarm",
+        "signalStrength": 73,
+        "batteryLevel": 92,
+        "actuatorsOpen": 0,
+        "humidity": 69,
+    },
+    "description": {"name": "Woonkamer"},
+}
+
+ZONE_ITEM = {
+    "id": 3073,
+    "name": "Woonkamer",
+    "set_temperature": 20.6,
+    "mode": "constantTemp",
+    "current_temperature": 21.5,
+    "raw_data": json.dumps(RAW_DATA),
+}
+
+
+def zone_item(**overrides):
+    """A copy of the documented zone entry with fields replaced."""
+    return {**ZONE_ITEM, **overrides}
+
+
+# ----------------------------
+# _parse_zone
+# ----------------------------
+
+def test_parse_zone_documented_payload():
+    zone = EpluconApi._parse_zone(ZONE_ITEM)
+
+    assert zone.id == 3073
+    assert zone.name == "Woonkamer"
+    assert zone.mode == "constantTemp"
+    assert zone.set_temperature == 20.6
+    assert zone.current_temperature == 21.5
+    assert zone.humidity == 69
+    assert zone.battery_level == 92
+    assert zone.signal_strength == 73
+    assert zone.actuators_open == 0
+    assert zone.zone_state == "noAlarm"
+    assert zone.relay_state == "on"
+    assert zone.algorithm == "cooling"
+
+
+@pytest.mark.parametrize(
+    "raw_data",
+    [
+        json.dumps({"zone": None}),
+        json.dumps({"zone": {"flags": None}}),
+        json.dumps({"zone": [1, 2]}),
+        json.dumps({"zone": {"flags": "on"}}),
+        json.dumps({"other": 1}),
+        json.dumps("a bare string"),
+        "not json at all",
+        None,
+        "",
+    ],
+    ids=[
+        "zone-null",
+        "flags-null",
+        "zone-not-an-object",
+        "flags-not-an-object",
+        "no-zone-key",
+        "not-an-object",
+        "unparseable",
+        "absent",
+        "empty",
+    ],
+)
+def test_parse_zone_keeps_top_level_fields_when_raw_data_is_unusable(raw_data):
+    """Unusable raw_data must not cost us the fields that did parse."""
+    zone = EpluconApi._parse_zone(zone_item(raw_data=raw_data))
+
+    assert zone.id == 3073
+    assert zone.name == "Woonkamer"
+    assert zone.current_temperature == 21.5
+    assert zone.set_temperature == 20.6
+    # Enrichment simply stays empty.
+    assert zone.humidity is None
+    assert zone.relay_state is None
+    assert zone.algorithm is None
+
+
+def test_parse_zone_partial_raw_data():
+    """A zone record missing flags still yields the fields it does have."""
+    zone = EpluconApi._parse_zone(
+        zone_item(raw_data=json.dumps({"zone": {"humidity": 55}}))
+    )
+
+    assert zone.humidity == 55
+    assert zone.relay_state is None
+
+
+@pytest.mark.parametrize(
+    "item",
+    [{"name": "Woonkamer"}, {"id": None}, {"id": "not-a-number"}, "a string"],
+    ids=["no-id", "null-id", "non-numeric-id", "not-an-object"],
+)
+def test_parse_zone_rejects_unidentifiable_entry(item):
+    with pytest.raises(ValueError):
+        EpluconApi._parse_zone(item)
+
+
+def test_parse_zone_accepts_string_id():
+    assert EpluconApi._parse_zone({"id": "3073", "name": "X"}).id == 3073
+
+
+# ----------------------------
+# get_zones
+# ----------------------------
+
+class FakeResponse:
+    """Minimal stand-in for an aiohttp response used as an async context manager."""
+
+    def __init__(self, status=200, payload=None, json_error=None):
+        self.status = status
+        self._payload = payload
+        self._json_error = json_error
+
+    async def json(self, content_type=None):
+        if self._json_error is not None:
+            raise self._json_error
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class FakeSession:
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def get(self, url, headers=None):
+        self.calls += 1
+        # Repeat the last response once the scripted ones run out.
+        index = min(self.calls - 1, len(self._responses) - 1)
+        return self._responses[index]
+
+
+def client(*responses):
+    return EpluconApi("token", "http://api.test", FakeSession(*responses))
+
+
+def ok(data, error_code=200):
+    return FakeResponse(payload={"auth": True, "data": data, "error_code": error_code})
+
+
+async def test_get_zones_parses_documented_response():
+    zones = await client(ok([ZONE_ITEM])).get_zones(1)
+
+    assert [z.name for z in zones] == ["Woonkamer"]
+
+
+async def test_get_zones_skips_bad_entry_but_keeps_the_rest():
+    """One unusable entry must not take the whole zone list with it."""
+    zones = await client(ok([{"name": "no id here"}, ZONE_ITEM])).get_zones(1)
+
+    assert [z.id for z in zones] == [3073]
+
+
+async def test_get_zones_returns_empty_on_406():
+    """406 means the module has no zones; not an error worth failing over."""
+    api = client(FakeResponse(status=406, payload={"message": "Account is not a zone-controller"}))
+
+    assert await api.get_zones(1) == []
+
+
+async def test_get_zones_406_warns_only_once(caplog):
+    api = client(FakeResponse(status=406, payload={"message": "Account is not a zone-controller"}))
+
+    for _ in range(3):
+        assert await api.get_zones(1) == []
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "does not expose zones" in warnings[0].message
+
+
+async def test_get_zones_406_in_body_only():
+    """Some portal errors carry the code in error_code rather than the status."""
+    api = client(FakeResponse(payload={"auth": True, "error_code": 406, "message": "nope"}))
+
+    assert await api.get_zones(1) == []
+
+
+async def test_get_zones_warns_once_per_module():
+    api = client(FakeResponse(status=406, payload={"message": "nope"}))
+
+    await api.get_zones(1)
+    await api.get_zones(2)
+
+    assert api._not_a_zone_controller == {1, 2}
+
+
+@pytest.mark.parametrize("status", [500, 502, 404])
+async def test_get_zones_raises_on_server_error(status):
+    with pytest.raises(ApiError):
+        await client(FakeResponse(status=status, payload={"message": "boom"})).get_zones(1)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+async def test_get_zones_raises_auth_error_on_unauthorized(status):
+    with pytest.raises(ApiAuthError):
+        await client(FakeResponse(status=status, payload=None)).get_zones(1)
+
+
+async def test_get_zones_raises_on_auth_false():
+    with pytest.raises(ApiAuthError):
+        await client(FakeResponse(payload={"auth": False, "data": []})).get_zones(1)
+
+
+async def test_get_zones_raises_on_error_code_mismatch():
+    with pytest.raises(ApiError):
+        await client(ok([], error_code=500)).get_zones(1)
+
+
+@pytest.mark.parametrize("payload", [{"auth": True}, {"auth": True, "data": None}, {"auth": True, "data": {}}])
+async def test_get_zones_raises_when_data_is_not_a_list(payload):
+    with pytest.raises(ApiError):
+        await client(FakeResponse(payload=payload)).get_zones(1)
+
+
+async def test_get_zones_raises_on_non_json_body():
+    """An HTML error page served with HTTP 200 must not pass silently."""
+    api = client(
+        FakeResponse(
+            json_error=aiohttp.ContentTypeError(None, None, message="not json")
+        )
+    )
+
+    with pytest.raises(ApiError):
+        await api.get_zones(1)
+
+
+async def test_get_zones_tolerates_string_error_code():
+    zones = await client(ok([ZONE_ITEM], error_code="200")).get_zones(1)
+
+    assert len(zones) == 1


### PR DESCRIPTION
This uses the documented public API to expose the zone controller and control panels as additional HA devices/entities.

Related discussion: #35.
Related issue: #28 

**Note that the target temperature cannot be actuated because this is not yet possible through the public API.**

Even though the feature is read-only, here are some example benefits:

- exposes current temperature/humidity from the sensors integrated in the control panels. This can be used as input to other automations instead of dedicated sensors.

- exposes the battery level, which is then displayed in the HA "maintenance" dashboard so batteries can be replaced on time.

Example screenshots:

<img width="1512" height="891" alt="control-panel" src="https://github.com/user-attachments/assets/e8188cbd-34ec-49d0-806e-3d8ded0c4062" />


<img width="1499" height="654" alt="controller" src="https://github.com/user-attachments/assets/e1973df3-c1a3-41b8-806a-0949884acd5c" />
